### PR TITLE
Targeting

### DIFF
--- a/src/js/client/GameEmitter.js
+++ b/src/js/client/GameEmitter.js
@@ -44,6 +44,11 @@ class GameEmitter {
     console.log('EMITTED SELL TOWER');
   }
 
+  setTowerTarget(tower, target) {
+    this.emit('set tower target', tower.id, target.id)
+    console.log('set tower target', tower.id, target.id);
+  }
+
   sendPerformance(data) {
     this.emit('send performance', data)
   }

--- a/src/js/client/renderers/BoardRenderer.js
+++ b/src/js/client/renderers/BoardRenderer.js
@@ -22,6 +22,11 @@ export default class BoardRenderer {
 
     this.app.view.id = "game-viewport"
     const displayBox = document.querySelector("#display-box")
+    // Prevent context menu from displaying
+    displayBox.addEventListener('contextmenu', (e) => {
+      e.preventDefault()
+    })
+
     displayBox.appendChild(this.app.view)
     this.app.renderer.backgroundColor = 0xFFFFFF
     this.app.renderer.view.style.border = '2px solid black'

--- a/src/js/client/renderers/GameRenderer.js
+++ b/src/js/client/renderers/GameRenderer.js
@@ -15,6 +15,7 @@ export default class GameRenderer {
     // @TODO Game should have an object of actions - shouldn't be done here!
     const actions = {
       selectEntity: game.selectEntity.bind(game),
+      setSelectedTowerTarget: game.setSelectedTowerTarget.bind(game),
     }
 
     this.gameHelpers = gameHelpers

--- a/src/js/client/renderers/enemies/EnemyRenderer.js
+++ b/src/js/client/renderers/enemies/EnemyRenderer.js
@@ -14,6 +14,10 @@ export default class EnemyRenderer extends UnitRenderer {
     const explosion = this.createExplosion(unit, container)
     const burnAnimation = this.createBurning(unit, container)
 
+    container.on('rightclick', () => {
+      this.actions.setSelectedTowerTarget(unit)
+    })
+
     return container
   }
 

--- a/src/js/client/socketListeners.js
+++ b/src/js/client/socketListeners.js
@@ -40,6 +40,11 @@ function setUpListeners(game, emitter) {
     game.receiveSellTower(towerId)
   })
 
+  socket.on('set tower target', (towerId, targetId) => {
+    console.log('setting tower with ID:', towerId, 'to target ID:', targetId);
+    game.setTowerTargetFromData(towerId, targetId)
+  })
+
   socket.on('update all', (data, time) => {
     game.updateAll(data, time)
   })

--- a/src/js/game/ClientGame.js
+++ b/src/js/game/ClientGame.js
@@ -114,6 +114,13 @@ class ClientGame extends Game {
     this.selectedEntity = entity
   }
 
+  setSelectedTowerTarget(target) {
+    const tower = this.selectedEntity
+    if (!target || !tower || tower.type !== 'Tower') { return }
+    tower.setTarget(target)
+    console.log('Set tower target!');
+  }
+
   @action updateAll(data, serverTime) {
     console.log('Updating all');
 

--- a/src/js/game/ClientGame.js
+++ b/src/js/game/ClientGame.js
@@ -114,28 +114,37 @@ class ClientGame extends Game {
     this.selectedEntity = entity
   }
 
+  /*
+   * Set the currently selected tower to have a new target.
+   */
   setSelectedTowerTarget(target) {
     const tower = this.selectedEntity
     if (!target || !tower || tower.type !== 'Tower') { return }
     this.sendSetTowerTarget(tower, target)
   }
 
+  /*
+   * Simply set the tower target. Inherit & override to send data to server.
+   */
   sendSetTowerTarget(tower, target) {
     console.log('In sendSetTowerTarget');
     this.setTowerTarget(tower, target)
   }
 
+  /*
+   * Given a tower and a target object, sets the tower to have that target.
+   * If a target is not passed, the tower tries to use data about its current
+   * target to set the target (for multiplayer syncing).
+   * If the tower also has no target, it attempts to select one.
+   */
   setTowerTarget(tower, target) {
-    // set to a specific target if target is passed
     if (target !== undefined) {
       return super.setTowerTarget(tower, target)
     }
-    // otherwise, set to current target or select one as normal
     if (tower.target && tower.target.id && this.enemies.byId[tower.target.id]) {
-      tower.setTarget(this.enemies.byId[tower.target.id])
-    } else {
-      tower.selectTarget()
+      return tower.setTarget(this.enemies.byId[tower.target.id])
     }
+    tower.selectTarget()
   }
 
   @action updateAll(data, serverTime) {

--- a/src/js/game/ClientGame.js
+++ b/src/js/game/ClientGame.js
@@ -117,8 +117,25 @@ class ClientGame extends Game {
   setSelectedTowerTarget(target) {
     const tower = this.selectedEntity
     if (!target || !tower || tower.type !== 'Tower') { return }
-    tower.setTarget(target)
-    console.log('Set tower target!');
+    this.sendSetTowerTarget(tower, target)
+  }
+
+  sendSetTowerTarget(tower, target) {
+    console.log('In sendSetTowerTarget');
+    this.setTowerTarget(tower, target)
+  }
+
+  setTowerTarget(tower, target) {
+    // set to a specific target if target is passed
+    if (target !== undefined) {
+      return super.setTowerTarget(tower, target)
+    }
+    // otherwise, set to current target or select one as normal
+    if (tower.target && tower.target.id && this.enemies.byId[tower.target.id]) {
+      tower.setTarget(this.enemies.byId[tower.target.id])
+    } else {
+      tower.selectTarget()
+    }
   }
 
   @action updateAll(data, serverTime) {
@@ -235,14 +252,6 @@ class ClientGame extends Game {
       unit.setBurningCooldown(data.burningInfo.cooldown.cooldownLength)
     }
     unit.burningInfo.cooldown.setTicksPassed(data.burningInfo.cooldown.ticksPassed)
-  }
-
-  setTowerTarget(tower) {
-    if (tower.target && tower.target.id && this.enemies.byId[tower.target.id]) {
-      tower.setTarget(this.enemies.byId[tower.target.id])
-    } else {
-      tower.selectTarget()
-    }
   }
 
   removeTowers(towersData, serverTime) {

--- a/src/js/game/ClientMultiGame.js
+++ b/src/js/game/ClientMultiGame.js
@@ -49,6 +49,11 @@ class ClientMultiGame extends ClientGame {
     this.emitter.sellTower(tower)
   }
 
+  sendSetTowerTarget(tower, target) {
+    super.sendSetTowerTarget(tower, target)
+    this.emitter.setTowerTarget(tower, target)
+  }
+
   newGame() {
     this.emitter.addNewGame()
   }

--- a/src/js/game/ClientMultiGame.js
+++ b/src/js/game/ClientMultiGame.js
@@ -49,6 +49,9 @@ class ClientMultiGame extends ClientGame {
     this.emitter.sellTower(tower)
   }
 
+  /*
+   * Trigger the setting of a tower's target. Emit the event to the server.
+   */
   sendSetTowerTarget(tower, target) {
     super.sendSetTowerTarget(tower, target)
     this.emitter.setTowerTarget(tower, target)

--- a/src/js/game/Game.js
+++ b/src/js/game/Game.js
@@ -270,6 +270,19 @@ export default class Game {
     tower.destroy()
   }
 
+  setTowerTargetFromData(towerId, targetId) {
+    const tower = this.towers.byId[towerId]
+    const target = this.enemies.byId[targetId]
+    console.log('Set tower target from data!');
+    return this.setTowerTarget(tower, target)
+  }
+
+  setTowerTarget(tower, target) {
+    if (!tower || !target) { return }
+    tower.setTarget(target)
+    return true
+  }
+
   endGame() {
     this.pause()
     this.towers.clear()

--- a/src/js/game/Game.js
+++ b/src/js/game/Game.js
@@ -270,13 +270,20 @@ export default class Game {
     tower.destroy()
   }
 
+  /*
+   * Given data about a tower and a target, finds those objects and sets
+   * the tower to have that target. Useful for server syncing.
+   */
   setTowerTargetFromData(towerId, targetId) {
     const tower = this.towers.byId[towerId]
     const target = this.enemies.byId[targetId]
-    console.log('Set tower target from data!');
     return this.setTowerTarget(tower, target)
   }
 
+  /*
+   * Given a tower and a target object, sets the tower to have that target.
+   * Fails if either are not provided.
+   */
   setTowerTarget(tower, target) {
     if (!tower || !target) { return }
     tower.setTarget(target)

--- a/src/js/server/socketListeners.js
+++ b/src/js/server/socketListeners.js
@@ -2,37 +2,48 @@
 export default function socketListeners(socket, emitter, serverFunctions) {
   socket.on('place tower', (tower) => {
     console.log('placing tower at:', tower.x, tower.y);
-    if (socket.gameManager && socket.gameManager.game) {
-      const success = socket.gameManager.game.placeTower(tower)
-      if (success) {
-        socket.broadcast.to(socket.roomId).emit('place tower', tower)
-      } else {
-        socket.emit('place tower failed', tower)
-      }
+    if (!socket.gameManager || !socket.gameManager.game) { return }
+    const success = socket.gameManager.game.placeTower(tower)
+    if (success) {
+      socket.broadcast.to(socket.roomId).emit('place tower', tower)
+    } else {
+      socket.emit('place tower failed', tower)
     }
   })
 
   socket.on('sell tower', (towerId) => {
     console.log('selling tower with ID:', towerId);
-    if (socket.gameManager && socket.gameManager.game) {
-      const sellSuccess = socket.gameManager.game.receiveSellTower(towerId)
-      if (sellSuccess) {
-        console.log('Sell tower success on server side!');
-        socket.broadcast.to(socket.roomId).emit('sell tower', towerId)
-      } else {
-        // @TODO Inform client that the tower sale failed
-      }
+    if (!socket.gameManager || !socket.gameManager.game) { return }
+    const sellSuccess = socket.gameManager.game.receiveSellTower(towerId)
+    if (sellSuccess) {
+      console.log('Sell tower success on server side!');
+      socket.broadcast.to(socket.roomId).emit('sell tower', towerId)
+    } else {
+      // @TODO Inform client that the tower sale failed
     }
   })
 
   socket.on('sell tower', (towerId) => {
     console.log('selling tower with ID:', towerId);
-    if (socket.gameManager && socket.gameManager.game) {
-      const sellSuccess = socket.gameManager.game.receiveSellTower(towerId)
-      if (sellSuccess) {
-        console.log('Sell tower success on server side!');
-        socket.broadcast.to(socket.roomId).emit('sell tower', towerId)
-      }
+    if (!socket.gameManager || !socket.gameManager.game) { return }
+    const sellSuccess = socket.gameManager.game.receiveSellTower(towerId)
+    if (sellSuccess) {
+      console.log('Sell tower success on server side!');
+      socket.broadcast.to(socket.roomId).emit('sell tower', towerId)
+    }
+  })
+
+  socket.on('set tower target', (towerId, targetId) => {
+    if (!socket.gameManager || !socket.gameManager.game) { return }
+    const game = socket.gameManager.game
+    const setTargetSuccess = game.setTowerTargetFromData(towerId, targetId)
+    // const setTargetSuccess = false
+    if (setTargetSuccess) {
+      console.log('Set tower target success on server side!');
+      socket.broadcast.to(socket.roomId).emit('set tower target', towerId, targetId)
+    } else {
+      // @TODO If it does not work, update socket with game data (or current target)
+      // NOTE: Can use work form menu branch to completely resync game if needed
     }
   })
 


### PR DESCRIPTION
Allow for manual targeting of towers.

* Prevent right-click default behaviour (context menu) on the game display
* Enemies register right clicks for targeting
* Ensure the selected tower targets an enemy when right-clicking on them
* Create emitted event for signalling a change in targeting for a specific tower
* Emit and receive targeting signal on clients/server